### PR TITLE
Fix typos in HTML meta and CSS

### DIFF
--- a/header.css
+++ b/header.css
@@ -91,7 +91,7 @@
   border-style: none;
   font-size: 14px;
   padding-left: 10px;
-  text-size-adjust: 100px;
+  text-size-adjust: 100%;
   flex: 1;
 }
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="wclassth=device-wclassth, initial-scale=1.0"
+      content="width=device-width, initial-scale=1.0"
     />
     <title>Blinkit</title>
     <link rel="stylesheet" href="styles.css" />
@@ -18,7 +18,7 @@
     <link rel="icon" type="image/x-icon" href="Images/faicon.png" />
   </head>
 
-  <body style="padding: 0px; margin: 0px; overflow-x: hclassden">
+  <body style="padding: 0px; margin: 0px; overflow-x: hidden">
     <div class="header-section">
       <div class="header">
         <div style="display: flex">


### PR DESCRIPTION
## Summary
- fix typos in viewport meta tag and body style
- correct `text-size-adjust` value in CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a33ad974483279d6d35793ce8209b