### PR TITLE
Add alt text for images

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,21 +22,18 @@
     <div class="header-section">
       <div class="header">
         <div style="display: flex">
-          <img
-            class="logo"
-            src="./Images/image 2.svg"
-          />
+          <img class="logo" src="./Images/image 2.svg" alt="Blinkit logo" />
           <div class="addressanddelivery">
             <p class="Delivery-time">Delivery in 8 minutes</p>
             <div class="addressandarrow">
               <p class="address">35A North Avenue Road...</p>
-              <img class="arrow" src="./Icons/Arrow.svg" />
+              <img class="arrow" src="./Icons/Arrow.svg" alt="Address arrow" />
             </div>
           </div>
         </div>
         <div class="search-bar-div">
           <div class="search-bar">
-            <img class="search-icon" src="./Icons/search-icon.svg" />
+            <img class="search-icon" src="./Icons/search-icon.svg" alt="Search" />
             <input class="search-input" type="text" placeholder="Search" />
           </div>
         </div>
@@ -46,7 +43,7 @@
           </div>
           <div class="button-1">
             <button class="mycart">
-              <img class="cart-icon" src="./Icons/Cart.svg" />
+              <img class="cart-icon" src="./Icons/Cart.svg" alt="Cart" />
               <a>My Cart</a>
             </button>
           </div>
@@ -67,77 +64,47 @@
     <div class="listandproducts">
       <div class="product-list">
         <div class="imgandname">
-          <img class="list-img" src="./Images/2380_1696572534396.avif" />
+          <img class="list-img" src="./Images/2380_1696572534396.avif" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
         <div class="imgandname">
-          <img
-            class="list-img"
-            src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/953_1657599742631.png"
-          />
+          <img class="list-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/953_1657599742631.png" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
         <div class="imgandname">
-          <img
-            class="list-img"
-            src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/28_1643445056245.png"
-          />
+          <img class="list-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/28_1643445056245.png" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
         <div class="imgandname">
-          <img
-            class="list-img"
-            src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/105_1668515747141.png"
-          />
+          <img class="list-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/105_1668515747141.png" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
         <div class="imgandname">
-          <img
-            class="list-img"
-            src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/209_1643445123315.png"
-          />
+          <img class="list-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/209_1643445123315.png" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
         <div class="imgandname">
-          <img
-            class="list-img"
-            src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/938_1681720325311.png"
-          />
+          <img class="list-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/938_1681720325311.png" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
         <div class="imgandname">
-          <img
-            class="list-img"
-            src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/107_1643445091063.png"
-          />
+          <img class="list-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/107_1643445091063.png" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
         <div class="imgandname">
-          <img
-            class="list-img"
-            src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/108_1669984636578.png"
-          />
+          <img class="list-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/108_1669984636578.png" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
         <div class="imgandname">
-          <img
-            class="list-img"
-            src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/971_1643445162896.png"
-          />
+          <img class="list-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/971_1643445162896.png" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
         <div class="imgandname">
-          <img
-            class="list-img"
-            src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/144_1643445112222.png"
-          />
+          <img class="list-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/144_1643445112222.png" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
         <div class="imgandname">
-          <img
-            class="list-img"
-            src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/1959_1687773864346.png"
-          />
+          <img class="list-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=180/app/images/category/cms_images/icon/1959_1687773864346.png" alt="Category image" />
           <p class="list-product-name">Biscut Gift Pack</p>
         </div>
       </div>
@@ -159,17 +126,11 @@
 
           <div class="main-cards">
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -187,17 +148,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -215,17 +170,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -243,17 +192,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -271,17 +214,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -299,17 +236,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -327,17 +258,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -355,17 +280,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -383,17 +302,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -411,17 +324,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -439,17 +346,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -467,17 +368,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -495,17 +390,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -523,17 +412,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>
@@ -551,17 +434,11 @@
             </div>
 
             <div class="main-card">
-              <img
-                class="card-img"
-                src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237"
-              />
+              <img class="card-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=900/app/assets/products/sliding_images/jpeg/d07574da-0d30-4acc-a5f2-99972848af54.jpg?ts=1717407237" alt="Good Day cookies" />
 
               <div class="card-info">
                 <div class="delivery-time">
-                  <img
-                    class="clock-img"
-                    src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png"
-                  />
+                  <img class="clock-img" src="https://cdn.grofers.com/cdn-cgi/image/f=auto,fit=scale-down,q=70,metadata=none,w=90/assets/eta-icons/15-mins.png" alt="15 mins" />
                   <p class="clock-text">9 MINS</p>
                 </div>
                 <p class="product-name">Britnia Good Day Fruit & Nut Cookies</p>


### PR DESCRIPTION
## Summary
- include descriptive alt text for all `<img>` tags

## Testing
- `grep -n "<img" index.html | grep -v alt`

------
https://chatgpt.com/codex/tasks/task_e_685a4541b7348327a728bb21cb00feff